### PR TITLE
feat: add .editorconfig to ensure consistency among editors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig helps maintain consistent coding styles across different editors and IDEs.
+# For more information, visit https://editorconfig.org
+root = true
+
+# Global settings for all files
+[*]
+indent_style = space
+indent_size = 4
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Specific settings for Python files
+[*.py]
+max_line_length = 79  # Adhere to PEP 8 line length


### PR DESCRIPTION
Added an `.editorconfig` file.

This file tells your editor to use spaces instead of tabs, to strip trailing whitespaces and to add a newline at the end of the file etc.

This will help our files to stay consistent